### PR TITLE
Updated workflow to use the deploy key to allow GitHub bot to push directly to main

### DIFF
--- a/.github/workflows/scrape_apod_daily.yml
+++ b/.github/workflows/scrape_apod_daily.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
After protecting the `main` branch. The GitHub bot was not able to push the new data to the `main` branch. To solve this issue, I have updated the ruleset by adding deploy key to the bypass list.