### PR TITLE
Fixed the ERR_TOO_MANY_REDIRECTS error

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -44,11 +44,6 @@ if not DEBUG:
     CSRF_TRUSTED_ORIGINS = ["https://myuniversehub.com", "https://www.myuniversehub.com", "https://104.248.40.52"]
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
-    SECURE_HSTS_SECONDS = 31536000
-    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
-    SECURE_HSTS_PRELOAD = True
-    SECURE_SSL_REDIRECT = True
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -48,6 +48,7 @@ if not DEBUG:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
     SECURE_SSL_REDIRECT = True
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Application definition
 


### PR DESCRIPTION
This PR fixes the ERR_TOO_MANY_REDIRECTS error that appeared after adding the following to `settings.py`

```python
    SECURE_HSTS_SECONDS = 31536000
    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
    SECURE_HSTS_PRELOAD = True
    SECURE_SSL_REDIRECT = True
```