### PR TITLE
Added a way to check APOD health

### DIFF
--- a/backend/gallery/urls.py
+++ b/backend/gallery/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     ),
     path("favourites/<str:email>/count/", views.getFavouritesArchiveSize, name="get_favourites_archive_size"),
     path("reset_password/", views.resetPassword, name="reset_password"),
+    path("apod-health/", views.apod_health_check, name="apod_health_check"),
 ]

--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -172,7 +172,7 @@ def resetPassword(request: Request) -> JsonResponse | HttpResponseBadRequest:
 
 def apod_health_check(request: Request) -> JsonResponse:
     try:
-        response = requests.head("https://apod.nasa.gov/", timeout=5)
+        response = requests.head("https://apod.nasa.gov/apod/archivepix.html", timeout=5)
         if response.status_code == 200:
             return JsonResponse({"status": "up"})
         else:

--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -173,7 +173,7 @@ def resetPassword(request: Request) -> JsonResponse | HttpResponseBadRequest:
 def apod_health_check(request: Request) -> JsonResponse:
     try:
         response = requests.head("https://apod.nasa.gov/apod/archivepix.html", timeout=5)
-        if response.status_code == 200:
+        if response.ok:
             return JsonResponse({"status": "up"})
         else:
             return JsonResponse({"status": "down"})

--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -170,6 +170,7 @@ def resetPassword(request: Request) -> JsonResponse | HttpResponseBadRequest:
         return HttpResponseBadRequest("User not found!")
 
 
+@api_view(["GET"])
 def apod_health_check(request: Request) -> JsonResponse:
     try:
         response = requests.head("https://apod.nasa.gov/apod/archivepix.html", timeout=5)

--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 
+import requests
 from django.db.models import Q
 from django.http import HttpResponseBadRequest, JsonResponse
 from rest_framework.decorators import api_view
@@ -167,3 +168,14 @@ def resetPassword(request: Request) -> JsonResponse | HttpResponseBadRequest:
 
     except UserAccount.DoesNotExist:
         return HttpResponseBadRequest("User not found!")
+
+
+def apod_health_check(request: Request) -> JsonResponse:
+    try:
+        response = requests.head("https://apod.nasa.gov/", timeout=5)
+        if response.status_code == 200:
+            return JsonResponse({"status": "up"})
+        else:
+            return JsonResponse({"status": "down"})
+    except requests.exceptions.RequestException:
+        return JsonResponse({"status": "down"})

--- a/frontend/src/components/ApodStatusOverlay.vue
+++ b/frontend/src/components/ApodStatusOverlay.vue
@@ -1,0 +1,47 @@
+<template>
+  <!-- Checking state -->
+  <div v-if="apodStatus === 'checking'" class="overlay" role="status" aria-live="polite" aria-busy="true">
+    <div class="text-center">
+      <div class="spinner-border" role="status" aria-label="Loading" style="width: 3rem; height: 3rem">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <p class="mt-3">Checking NASA APOD service status.</p>
+    </div>
+  </div>
+
+  <!-- Down state -->
+  <div v-else-if="apodStatus === 'down'" class="overlay" role="alert" aria-live="assertive">
+    <div class="text-center">
+      <h4 class="alert-heading"><i class="fas fa-meteor me-2" aria-hidden="true" />APOD service unavailable</h4>
+      <p class="mt-3 mb-0">
+        We're currently unable to connect to NASA's Astronomy Picture of the Day (APOD) service. Please try again later.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "ApodStatusOverlay",
+  computed: {
+    apodStatus() {
+      return this.$store.state.apodStatus;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none; /* Allows clicks to pass through the overlay */
+}
+</style>

--- a/frontend/src/components/ApodStatusOverlay.vue
+++ b/frontend/src/components/ApodStatusOverlay.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- Checking state -->
   <div v-if="apodStatus === 'checking'" class="overlay" role="status" aria-live="polite" aria-busy="true">
-    <div class="text-center">
+    <div class="container text-center">
       <div class="spinner-border" role="status" aria-label="Loading" style="width: 3rem; height: 3rem">
         <span class="visually-hidden">Loading...</span>
       </div>
@@ -11,7 +11,7 @@
 
   <!-- Down state -->
   <div v-else-if="apodStatus === 'down'" class="overlay" role="alert" aria-live="assertive">
-    <div class="text-center">
+    <div class="container text-center">
       <h4 class="alert-heading"><i class="fas fa-meteor me-2" aria-hidden="true" />APOD service unavailable</h4>
       <p class="mt-3 mb-0">
         We're currently unable to connect to NASA's Astronomy Picture of the Day (APOD) service. Please try again later.

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -89,6 +89,19 @@
             <hr class="d-block d-lg-none" />
           </div>
           <div class="col-auto d-flex p-0 align-items-center">
+            <!-- APOD health status indicator -->
+            <div
+              data-cy="apod-status-indicator"
+              data-bs-toggle="tooltip"
+              data-bs-placement="bottom"
+              data-bs-title="APOD health status"
+              class="border-container d-flex align-items-center text-dark me-2"
+              style="cursor: default"
+            >
+              {{ getApodStatusText }}
+              <i :class="getApodStatusIcon" />
+            </div>
+
             <!-- GitHub logo and star count -->
             <a
               :href="githubRepoUrl"
@@ -163,6 +176,7 @@ export default {
       NONE: "",
       starCount: 0,
       githubRepoUrl: "https://github.com/ImadSaddik/My_Universe_Hub",
+      apodStatus: "checking",
     };
   },
   computed: {
@@ -175,9 +189,34 @@ export default {
     getSelectedNavbarItem() {
       return this.$store.state.selectedNavbarItem;
     },
+    getApodStatusIcon() {
+      if (this.apodStatus === "checking") {
+        return "ms-2 fa-solid fa-hurricane fa-spin";
+      }
+      if (this.apodStatus === "up") {
+        return "ms-2 fa-solid fa-circle text-success";
+      }
+      if (this.apodStatus === "down") {
+        return "ms-2 fa-solid fa-circle text-danger";
+      }
+      return "";
+    },
+    getApodStatusText() {
+      if (this.apodStatus === "checking") {
+        return "Checking";
+      }
+      if (this.apodStatus === "up") {
+        return "APOD is up";
+      }
+      if (this.apodStatus === "down") {
+        return "APOD is down";
+      }
+      return "";
+    },
   },
   async mounted() {
     await this.fetchGitHubStars();
+    await this.checkApodHealth();
   },
   methods: {
     getNavbarItemClass(page) {
@@ -210,6 +249,16 @@ export default {
           .catch((error) => {});
       } catch (error) {
         console.error("Error fetching GitHub star count:", error);
+      }
+    },
+    async checkApodHealth() {
+      this.apodStatus = "checking";
+      try {
+        const response = await axios.get("/api/v1/apod-health/");
+        this.apodStatus = response.data.status;
+      } catch (error) {
+        console.error("Error checking APOD health:", error);
+        this.apodStatus = "down";
       }
     },
   },

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -180,10 +180,12 @@ export default {
       NONE: "",
       starCount: 0,
       githubRepoUrl: "https://github.com/ImadSaddik/My_Universe_Hub",
-      apodStatus: this.$store.state.apodStatus || "checking",
     };
   },
   computed: {
+    apodStatus() {
+      return this.$store.state.apodStatus;
+    },
     isLoggedOff() {
       return this.$store.state.token === "";
     },
@@ -256,16 +258,14 @@ export default {
       }
     },
     async checkApodHealth() {
-      this.apodStatus = "checking";
-      this.$store.commit("setApodStatus", this.apodStatus);
+      this.$store.commit("setApodStatus", "checking");
       try {
         const response = await axios.get("/api/v1/apod-health/");
-        this.apodStatus = response.data.status;
+        this.$store.commit("setApodStatus", response.data.status);
       } catch (error) {
         console.error("Error checking APOD health:", error);
-        this.apodStatus = "down";
+        this.$store.commit("setApodStatus", "down");
       }
-      this.$store.commit("setApodStatus", this.apodStatus);
     },
   },
 };

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -88,7 +88,8 @@
             </RouterLink>
             <hr class="d-block d-lg-none" />
           </div>
-          <div class="col-auto d-flex p-0 align-items-center">
+
+          <div class="col-auto d-flex p-0">
             <!-- APOD health status indicator -->
             <div
               data-cy="apod-status-indicator"

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -95,11 +95,15 @@
               data-bs-toggle="tooltip"
               data-bs-placement="bottom"
               data-bs-title="APOD health status"
+              tabindex="0"
+              role="status"
+              aria-live="polite"
               class="border-container d-flex align-items-center text-dark me-2"
               style="cursor: default"
+              :aria-label="getApodStatusText"
             >
               {{ getApodStatusText }}
-              <i :class="getApodStatusIcon" />
+              <i :class="getApodStatusIcon" aria-hidden="true" />
             </div>
 
             <!-- GitHub logo and star count -->
@@ -176,7 +180,7 @@ export default {
       NONE: "",
       starCount: 0,
       githubRepoUrl: "https://github.com/ImadSaddik/My_Universe_Hub",
-      apodStatus: "checking",
+      apodStatus: this.$store.state.apodStatus || "checking",
     };
   },
   computed: {
@@ -253,6 +257,7 @@ export default {
     },
     async checkApodHealth() {
       this.apodStatus = "checking";
+      this.$store.commit("setApodStatus", this.apodStatus);
       try {
         const response = await axios.get("/api/v1/apod-health/");
         this.apodStatus = response.data.status;
@@ -260,6 +265,7 @@ export default {
         console.error("Error checking APOD health:", error);
         this.apodStatus = "down";
       }
+      this.$store.commit("setApodStatus", this.apodStatus);
     },
   },
 };

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -91,21 +91,21 @@
 
           <div class="col-auto d-flex p-0">
             <!-- APOD health status indicator -->
-            <div
+            <a
+              :href="apodUrl"
               data-cy="apod-status-indicator"
+              target="_blank"
               data-bs-toggle="tooltip"
               data-bs-placement="bottom"
               data-bs-title="APOD health status"
-              tabindex="0"
               role="status"
               aria-live="polite"
               class="border-container d-flex align-items-center text-dark me-2"
-              style="cursor: default"
               :aria-label="getApodStatusText"
             >
               {{ getApodStatusText }}
               <i :class="getApodStatusIcon" aria-hidden="true" />
-            </div>
+            </a>
 
             <!-- GitHub logo and star count -->
             <a
@@ -181,6 +181,7 @@ export default {
       NONE: "",
       starCount: 0,
       githubRepoUrl: "https://github.com/ImadSaddik/My_Universe_Hub",
+      apodUrl: "https://apod.nasa.gov/apod/archivepix.html",
     };
   },
   computed: {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -3,6 +3,7 @@ import axios from "axios";
 
 export default createStore({
   state: {
+    apodStatus: "down",
     isAuthenticated: false,
     token: localStorage.getItem("token") || "",
     email: localStorage.getItem("email") || "",
@@ -26,6 +27,9 @@ export default createStore({
     },
     setSelectedNavbarItem(state, selectedNavbarItem) {
       state.selectedNavbarItem = selectedNavbarItem;
+    },
+    setApodStatus(state, status) {
+      state.apodStatus = status;
     },
   },
   actions: {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -3,7 +3,7 @@ import axios from "axios";
 
 export default createStore({
   state: {
-    apodStatus: "down",
+    apodStatus: "checking",
     isAuthenticated: false,
     token: localStorage.getItem("token") || "",
     email: localStorage.getItem("email") || "",

--- a/frontend/src/views/FavouritesView.vue
+++ b/frontend/src/views/FavouritesView.vue
@@ -75,6 +75,12 @@ export default {
   created() {
     document.title = "Favourites";
   },
+  async mounted() {
+    if (this.apodStatus === "up") {
+      await this.getFavouritesArchive();
+      await this.getFavouritesArchiveSize();
+    }
+  },
   methods: {
     async increaseLimit() {
       await this.getFavouritesArchive();

--- a/frontend/src/views/FavouritesView.vue
+++ b/frontend/src/views/FavouritesView.vue
@@ -1,5 +1,7 @@
 <template>
-  <div>
+  <ApodStatusOverlay />
+
+  <div v-if="apodStatus === 'up'">
     <div class="background-image" aria-hidden="true" />
     <div v-if="isLoggedIn && archive.length !== 0" class="mt-3">
       <GallerySection
@@ -30,6 +32,7 @@ import axios from "axios";
 import GallerySection from "@/components/GallerySection.vue";
 import BackToTopVue from "@/components/BackToTop.vue";
 import ImageDetails from "@/components/ImageDetails.vue";
+import ApodStatusOverlay from "@/components/ApodStatusOverlay.vue";
 
 export default {
   name: "FavouritesView",
@@ -37,6 +40,7 @@ export default {
     GallerySection,
     BackToTopVue,
     ImageDetails,
+    ApodStatusOverlay,
   },
   data() {
     return {
@@ -47,6 +51,9 @@ export default {
     };
   },
   computed: {
+    apodStatus() {
+      return this.$store.state.apodStatus;
+    },
     isLoggedIn() {
       return this.$store.state.token !== "";
     },
@@ -57,12 +64,16 @@ export default {
       return this.archive.length < this.archiveFullSize;
     },
   },
+  watch: {
+    apodStatus(newStatus, oldStatus) {
+      if (newStatus === "up" && oldStatus !== "up") {
+        this.getFavouritesArchive();
+        this.getFavouritesArchiveSize();
+      }
+    },
+  },
   created() {
     document.title = "Favourites";
-  },
-  async mounted() {
-    await this.getFavouritesArchive();
-    await this.getFavouritesArchiveSize();
   },
   methods: {
     async increaseLimit() {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -81,6 +81,12 @@ export default {
     document.title = "Home";
     this.$store.commit("setSelectedNavbarItem", "home");
   },
+  async mounted() {
+    if (this.apodStatus === "up") {
+      await this.getArchive();
+      await this.getArchiveSize();
+    }
+  },
   methods: {
     async search(query) {
       this.query = query;

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,14 +1,19 @@
 <template>
-  <SearchSection @search="(query) => search(query)" />
-  <GallerySection
-    :archive="getUpdatedArchive"
-    :should-show-load-more-button="shouldShowLoadMoreButton"
-    :search-result-count="searchArchiveSize"
-    @selected-item="(value) => (selectedItem = value)"
-    @increase-limit="increaseLimit()"
-  />
-  <BackToTopVue />
-  <ImageDetails :item="selectedItem" />
+  <ApodStatusOverlay />
+
+  <!-- Up state -->
+  <div v-if="apodStatus === 'up'">
+    <SearchSection @search="(query) => search(query)" />
+    <GallerySection
+      :archive="getUpdatedArchive"
+      :should-show-load-more-button="shouldShowLoadMoreButton"
+      :search-result-count="searchArchiveSize"
+      @selected-item="(value) => (selectedItem = value)"
+      @increase-limit="increaseLimit()"
+    />
+    <BackToTopVue />
+    <ImageDetails :item="selectedItem" />
+  </div>
 </template>
 
 <script>
@@ -17,6 +22,7 @@ import SearchSection from "@/components/SearchSection.vue";
 import GallerySection from "@/components/GallerySection.vue";
 import BackToTopVue from "@/components/BackToTop.vue";
 import ImageDetails from "@/components/ImageDetails.vue";
+import ApodStatusOverlay from "@/components/ApodStatusOverlay.vue";
 
 export default {
   name: "HomeView",
@@ -25,6 +31,7 @@ export default {
     GallerySection,
     BackToTopVue,
     ImageDetails,
+    ApodStatusOverlay,
   },
   data() {
     return {
@@ -39,6 +46,9 @@ export default {
     };
   },
   computed: {
+    apodStatus() {
+      return this.$store.state.apodStatus;
+    },
     getUpdatedArchive() {
       const archive = this.query.trim().length === 0 ? this.archive : this.searchArchive;
 
@@ -59,13 +69,17 @@ export default {
       }
     },
   },
+  watch: {
+    apodStatus(newStatus, oldStatus) {
+      if (newStatus === "up" && oldStatus !== "up") {
+        this.getArchive();
+        this.getArchiveSize();
+      }
+    },
+  },
   created() {
     document.title = "Home";
     this.$store.commit("setSelectedNavbarItem", "home");
-  },
-  async mounted() {
-    await this.getArchive();
-    await this.getArchiveSize();
   },
   methods: {
     async search(query) {

--- a/frontend/src/views/TodayPictureView.vue
+++ b/frontend/src/views/TodayPictureView.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="container pt-2 pt-sm-5">
+  <ApodStatusOverlay />
+
+  <div v-if="apodStatus === 'up'" class="container pt-2 pt-sm-5">
     <div v-if="!error">
       <div v-if="isTodayEntryAvailable">
         <div class="row m-0 my-3 d-flex flex-column">
@@ -88,10 +90,13 @@
 
 <script>
 import axios from "axios";
+import ApodStatusOverlay from "@/components/ApodStatusOverlay.vue";
 
 export default {
   name: "TodayPictureView",
-  components: {},
+  components: {
+    ApodStatusOverlay,
+  },
   data() {
     return {
       data: null,
@@ -99,6 +104,9 @@ export default {
     };
   },
   computed: {
+    apodStatus() {
+      return this.$store.state.apodStatus;
+    },
     isLoggedIn() {
       return this.$store.state.token !== "";
     },
@@ -117,11 +125,15 @@ export default {
       }
     },
   },
+  watch: {
+    apodStatus(newStatus, oldStatus) {
+      if (newStatus === "up" && oldStatus !== "up") {
+        this.getTodayPicture();
+      }
+    },
+  },
   created() {
     document.title = "Today's Picture";
-  },
-  async mounted() {
-    await this.getTodayPicture();
   },
   methods: {
     async getTodayPicture() {

--- a/frontend/src/views/TodayPictureView.vue
+++ b/frontend/src/views/TodayPictureView.vue
@@ -135,6 +135,11 @@ export default {
   created() {
     document.title = "Today's Picture";
   },
+  async mounted() {
+    if (this.apodStatus === "up") {
+      await this.getTodayPicture();
+    }
+  },
   methods: {
     async getTodayPicture() {
       await axios

--- a/frontend/src/views/TrendingView.vue
+++ b/frontend/src/views/TrendingView.vue
@@ -65,6 +65,12 @@ export default {
   created() {
     document.title = "Trending";
   },
+  async mounted() {
+    if (this.apodStatus === "up") {
+      await this.getTrendingArchive();
+      await this.getTrendingArchiveSize();
+    }
+  },
   methods: {
     async getTrendingArchive() {
       const start_index = this.archive.length;

--- a/frontend/src/views/TrendingView.vue
+++ b/frontend/src/views/TrendingView.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="mt-3">
+  <ApodStatusOverlay />
+
+  <div v-if="apodStatus === 'up'" class="mt-3">
     <GallerySection
       :archive="getArchive"
       :should-show-load-more-button="shouldShowLoadMoreButton"
@@ -16,6 +18,7 @@ import axios from "axios";
 import GallerySection from "@/components/GallerySection.vue";
 import BackToTopVue from "@/components/BackToTop.vue";
 import ImageDetails from "@/components/ImageDetails.vue";
+import ApodStatusOverlay from "@/components/ApodStatusOverlay.vue";
 
 export default {
   name: "TrendingView",
@@ -23,6 +26,7 @@ export default {
     GallerySection,
     BackToTopVue,
     ImageDetails,
+    ApodStatusOverlay,
   },
   data() {
     return {
@@ -33,6 +37,9 @@ export default {
     };
   },
   computed: {
+    apodStatus() {
+      return this.$store.state.apodStatus;
+    },
     getArchive() {
       if (this.isUserLoggedOff) {
         return this.removeLikes();
@@ -47,12 +54,16 @@ export default {
       return this.archive.length < this.archiveFullSize;
     },
   },
+  watch: {
+    apodStatus(newStatus, oldStatus) {
+      if (newStatus === "up" && oldStatus !== "up") {
+        this.getTrendingArchive();
+        this.getTrendingArchiveSize();
+      }
+    },
+  },
   created() {
     document.title = "Trending";
-  },
-  async mounted() {
-    await this.getTrendingArchive();
-    await this.getTrendingArchiveSize();
   },
   methods: {
     async getTrendingArchive() {

--- a/frontend/tests/HomeView.spec.js
+++ b/frontend/tests/HomeView.spec.js
@@ -12,6 +12,7 @@ const createMockStore = (initialState = {}) => {
   const defaultState = {
     token: "",
     selectedNavbarItem: "home",
+    apodStatus: "up",
   };
 
   mockSetSelectedNavbarItem = vi.fn((state, item) => {


### PR DESCRIPTION
Since my website depends on [APOD](https://apod.nasa.gov/apod/archivepix.html). It is important to know the health of that website.

Recently, I was not able to see images on my website because the APOD website was down. I know this is not ideal, I should download the images and store them on my server to not rely on APOD, but since I don't have a lot of storage on my VM, I can't.

So, this PR adds a health check before showing the content of the page. If APOD is healthy, we show the images. Is it is down for some reason, we show a text saying that something bad happened to APOD, please retry later.