### PR TITLE
Load IP address from HTTP_X_FORWARDED_FOR

### DIFF
--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -290,8 +290,7 @@ def log_user_visit(request: Request) -> JsonResponse | HttpResponseBadRequest:
             return HttpResponseBadRequest("Email is required.")
 
         user = UserAccount.objects.get(email=email)
-        logger.info(f"Request.META: {request.META}")
-        ip_address = request.META.get("REMOTE_ADDR")
+        ip_address = request.META.get("HTTP_X_FORWARDED_FOR")
         user_agent = request.META.get("HTTP_USER_AGENT", "")[:255]
 
         UserVisit.objects.create(

--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -289,9 +289,16 @@ def log_user_visit(request: Request) -> JsonResponse | HttpResponseBadRequest:
             logger.error("Email is required in log_user_visit.")
             return HttpResponseBadRequest("Email is required.")
 
+        # According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For
+        # The syntax for the X-Forwarded-For header is a comma-separated list of IP addresses.
+        # The first IP address in the list is the original client IP address.
+        x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if x_forwarded_for:
+            ip_address = x_forwarded_for.split(",")[0].strip()
+        else:
+            ip_address = request.META.get("REMOTE_ADDR", "")
+
         user = UserAccount.objects.get(email=email)
-        remote_address = request.META.get("REMOTE_ADDR", "")
-        ip_address = request.META.get("HTTP_X_FORWARDED_FOR", remote_address)
         user_agent = request.META.get("HTTP_USER_AGENT", "")[:255]
 
         UserVisit.objects.create(

--- a/backend/gallery/views.py
+++ b/backend/gallery/views.py
@@ -290,7 +290,8 @@ def log_user_visit(request: Request) -> JsonResponse | HttpResponseBadRequest:
             return HttpResponseBadRequest("Email is required.")
 
         user = UserAccount.objects.get(email=email)
-        ip_address = request.META.get("HTTP_X_FORWARDED_FOR")
+        remote_address = request.META.get("REMOTE_ADDR", "")
+        ip_address = request.META.get("HTTP_X_FORWARDED_FOR", remote_address)
         user_agent = request.META.get("HTTP_USER_AGENT", "")[:255]
 
         UserVisit.objects.create(


### PR DESCRIPTION
In this PR, I replaced `REMOTE_ADDR` with `HTTP_X_FORWARDED_FOR` because I am using Gunicorn behind Nginx with a proxy setup. Nginx sets `X-Forwarded-For` to pass the original client IP.