### PR TITLE
Fix pointer events in ApodStatusOverlay to allow text selection

### DIFF
--- a/frontend/src/components/ApodStatusOverlay.vue
+++ b/frontend/src/components/ApodStatusOverlay.vue
@@ -42,6 +42,10 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none; /* Allows clicks to pass through the overlay */
+  pointer-events: none;
+}
+
+.container {
+  pointer-events: auto;
 }
 </style>


### PR DESCRIPTION
**Problem**: The overlay's `pointer-events: none` CSS property prevented user interactions with the content, making it impossible to select text like "APOD service unavailable" while still allowing clicks to pass through the background.

**Solution**: Added `pointer-events: auto` to the `.container` class to re-enable interactions within the content area while keeping the overlay background non-interactive.

**Changes**:

- Users can now select text and interact with content inside the overlay
- Background clicks still pass through to underlying elements
- Maintains existing overlay functionality and accessibility