### PR TITLE
Added robots.txt to control crawlers

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /admin/
+Disallow: /api/v1/


### PR DESCRIPTION
This PR introduces a `robots.txt` file in the public folder to allow all crawlers except for `/admin/` and `/api/v1/` paths.