### PR TITLE
Fixed the inheritance from self issue

### DIFF
--- a/backend/gallery/serializers.py
+++ b/backend/gallery/serializers.py
@@ -1,11 +1,12 @@
-from rest_framework import serializers
-from djoser.serializers import UserCreateSerializer
 from django.contrib.auth import get_user_model
+from djoser.serializers import UserCreateSerializer as DjoserUserCreateSerializer
+from rest_framework import serializers
+
 from .models import Gallery
 
 
-class UserCreateSerializer(UserCreateSerializer):
-    class Meta(UserCreateSerializer.Meta):
+class UserCreateSerializer(DjoserUserCreateSerializer):
+    class Meta(DjoserUserCreateSerializer.Meta):
         model = get_user_model()
         fields = ("id", "email", "name", "password")
 


### PR DESCRIPTION
In [serializers.py](https://github.com/ImadSaddik/My_Universe_Hub/blob/main/backend/gallery/serializers.py), I was inheriting from `UserCreateSerializer` which I imported from `djoser.serializers`, but my class had the same name.

```python
class UserCreateSerializer(UserCreateSerializer):
    ...
```

`Pylance` was not happy about this, so it raised an error saying "Class cannot derive from itself"

In this PR, I solved this issue by giving an alias to the class that I imported from djoser. 

```python
from django.contrib.auth import get_user_model
from djoser.serializers import UserCreateSerializer as DjoserUserCreateSerializer


class UserCreateSerializer(DjoserUserCreateSerializer):
    class Meta(DjoserUserCreateSerializer.Meta):
        model = get_user_model()
        fields = ("id", "email", "name", "password")
```